### PR TITLE
Minor tweaks

### DIFF
--- a/examples/css-background.html
+++ b/examples/css-background.html
@@ -24,13 +24,12 @@
        * Set some custom options
        * See: http://www.resrc.it/docs/javascript/0.8#options
        */
-      var defaults = {
+      resrc.configure({
         resrcOnResizeDown : true,
         resrcOnPinch : true,
         imageQuality : 100,
         pixelRounding : 1
-      };
-      resrc.options = resrc.extend(resrc.options, defaults);
+      });
       resrc.resrc();
     });
   </script>

--- a/src/resrc.js
+++ b/src/resrc.js
@@ -789,6 +789,15 @@
 
 
   /**
+   * Utility method for setting resrc options. Merges over the top of any current values
+   * @param newOptions {Object}  New options to merge with current ones
+   */
+  var extendResrcOptions = function(newOptions){
+      mergeObject(options,newOptions);
+  };
+
+
+  /**
    * Expose various private functions as public methods.
    */
   resrc.ready = domReady;
@@ -797,5 +806,6 @@
   resrc.getElementsByClassName = getElementsByClassName;
   resrc.options = options;
   resrc.extend = mergeObject;
+  resrc.configure = extendResrcOptions;
 
 }(window.resrc = window.resrc || {}));

--- a/src/resrc.js
+++ b/src/resrc.js
@@ -166,7 +166,8 @@
     var searchVal;
     var index;
     var res;
-    imgPath = parseUri(url).url ? parseUri(url).path + "?" + parseUri(url).query : parseUri(url).path;
+    var parsedUri = parseUri(url);
+    imgPath = parsedUri.url ? parsedUri.path + "?" + parsedUri.query : parsedUri.path;
     searchVal = /(https?):|(\/\/)/;
     index = imgPath.search(searchVal);
     res = imgPath.substring(index);
@@ -216,7 +217,8 @@
    */
   var parseSrcToUniformFormat = function (src, server) {
     if (src.match(/\/\//g).length > 1) {
-      return parseUri(src).authority !== server ? src.replace(parseUri(src).protocol + "://" + parseUri(src).authority, getProtocol(options.ssl) + server) : src;
+        var parsedUri = parseUri(src);
+      return parsedUri.authority !== server ? src.replace(parsedUri.protocol + "://" + parsedUri.authority, getProtocol(options.ssl) + server) : src;
     }
     return getProtocol(options.ssl) + server + "/" + src;
   };

--- a/src/resrc.js
+++ b/src/resrc.js
@@ -802,7 +802,7 @@
    * Expose various private functions as public methods.
    */
   resrc.ready = domReady;
-  resrc.resrc = initResrc;
+  resrc.resrc = resrc.run = initResrc;
   resrc.getResrcImageObject = getResrcImageObject;
   resrc.getElementsByClassName = getElementsByClassName;
   resrc.options = options;

--- a/src/resrc.js
+++ b/src/resrc.js
@@ -794,6 +794,7 @@
    */
   var extendResrcOptions = function(newOptions){
       mergeObject(options,newOptions);
+      return resrc;
   };
 
 


### PR DESCRIPTION
Noticed multiple identical calls to parseUri(url) in a couple of methods... it's only a small change but seems it  would be more efficient to parse the url once and then re-use the returned object.

Also added `resrc.configure({/* options */})` as a shorthand to `resrc.extend(resrc.options,{/*options*/})` to make my code look nicer :)

Haven't included tests as changes are small and obvious - plus the contributing guidelines don't specify a testing framework or folder to put them in...