### PR TITLE
Adds sanity check for parseSrcToUniformFormat

### DIFF
--- a/src/resrc.js
+++ b/src/resrc.js
@@ -231,7 +231,8 @@
    * @returns {string}
    */
   var parseSrcToUniformFormat = function (src, server) {
-    if (src.match(/\/\//g).length > 1) {
+    var match = src.match(/\/\//g);
+    if (match && match.length > 1) {
       var parsedUri = parseUri(src);
       return parsedUri.authority !== server ? src.replace(parsedUri.protocol + "://" + parsedUri.authority, getProtocol(options.ssl) + server) : src;
     }


### PR DESCRIPTION
This method breaks when a non-empty and non-url like src is given.
The `src.match` will return `null` and the rest of the script and
image replacement will break on an error because `null` has no
`length` property:

> Uncaught TypeError: Cannot read property 'length' of null